### PR TITLE
Move client init outside of middleware

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -3,13 +3,13 @@ import React from 'react';
 import Styletron from 'styletron-client';
 import {StyletronProvider} from 'styletron-react';
 
+const styleElements = document.getElementsByClassName(
+  '_styletron_hydrate_'
+);
+const styletron = new Styletron(styleElements);
+
 export default () => (ctx, next) => {
   if (ctx.element) {
-    const styleElements = document.getElementsByClassName(
-      '_styletron_hydrate_'
-    );
-    const styletron = new Styletron(styleElements);
-
     ctx.element = (
       <StyletronProvider styletron={styletron}>{ctx.element}</StyletronProvider>
     );

--- a/src/browser.js
+++ b/src/browser.js
@@ -3,13 +3,16 @@ import React from 'react';
 import Styletron from 'styletron-client';
 import {StyletronProvider} from 'styletron-react';
 
-const styleElements = document.getElementsByClassName(
-  '_styletron_hydrate_'
-);
-const styletron = new Styletron(styleElements);
+let styletron;
 
 export default () => (ctx, next) => {
   if (ctx.element) {
+    if (!styletron) {
+      const styleElements = document.getElementsByClassName(
+        '_styletron_hydrate_'
+      );
+      styletron = new Styletron(styleElements);
+    }
     ctx.element = (
       <StyletronProvider styletron={styletron}>{ctx.element}</StyletronProvider>
     );


### PR DESCRIPTION
Fixes https://github.com/fusionjs/fusion-plugin-styletron-react/issues/19

Note: even moving the client instance initialization into `SingletonPlugin` constructor doesn't stop it from being re-called on HMR.