### PR TITLE
Add legacy context API provider

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -21,15 +21,27 @@ const SilverPanel = styled('div', {
   backgroundColor: 'silver',
 });
 
+const LegacyComponent = (props, ctx) => {
+  ctx.styletron.injectDeclaration({prop: 'color', val: 'red'});
+  return <div />;
+};
+
+LegacyComponent.contextTypes = {styletron: () => {}};
+
 tape('Server plugin', t => {
   const ctx: Context = ({
-    element: <SilverPanel />,
+    element: (
+      <div>
+        <SilverPanel />
+        <LegacyComponent />
+      </div>
+    ),
     template: {
       head: {
         push(h) {
           t.equal(
             consumeSanitizedHTML(h),
-            '<style class="_styletron_hydrate_">.ae{background-color:silver}</style>',
+            '<style class="_styletron_hydrate_">.ae{background-color:silver}.af{color:red}</style>',
             'Pushes generated styles to head'
           );
         },

--- a/src/browser.js
+++ b/src/browser.js
@@ -14,6 +14,7 @@ import type {FusionPlugin} from 'fusion-core';
 import {Provider as StyletronProvider} from 'styletron-react';
 import {Client as Styletron} from 'styletron-engine-atomic';
 
+import LegacyProvider from './legacy-provider.js';
 import {injectDeclarationCompatMixin} from './inject-declaration-compat-mixin.js';
 
 const StyletronCompat = injectDeclarationCompatMixin(Styletron);
@@ -31,7 +32,9 @@ const plugin =
           });
         }
         ctx.element = (
-          <StyletronProvider value={engine}>{ctx.element}</StyletronProvider>
+          <StyletronProvider value={engine}>
+            <LegacyProvider value={engine}>{ctx.element}</LegacyProvider>
+          </StyletronProvider>
         );
       }
 

--- a/src/legacy-provider.js
+++ b/src/legacy-provider.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/**
+ * Provides styletron instance via old context API
+ */
+
+class LegacyStyletronProvider extends React.Component {
+  getChildContext() {
+    return {styletron: this.styletron};
+  }
+  constructor(props, context) {
+    super(props, context);
+    this.styletron = props.value;
+  }
+  render() {
+    return React.Children.only(this.props.children);
+  }
+}
+
+LegacyStyletronProvider.childContextTypes = {
+  styletron: noop,
+};
+
+export default LegacyStyletronProvider;
+
+function noop() {}

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ import type {FusionPlugin} from 'fusion-core';
 import {Provider as StyletronProvider} from 'styletron-react';
 import {Server as Styletron} from 'styletron-engine-atomic';
 
+import LegacyProvider from './legacy-provider.js';
 import {injectDeclarationCompatMixin} from './inject-declaration-compat-mixin.js';
 
 const StyletronCompat = injectDeclarationCompatMixin(Styletron);
@@ -26,7 +27,9 @@ const plugin =
         const engine = new StyletronCompat();
 
         ctx.element = (
-          <StyletronProvider value={engine}>{ctx.element}</StyletronProvider>
+          <StyletronProvider value={engine}>
+            <LegacyProvider value={engine}>{ctx.element}</LegacyProvider>
+          </StyletronProvider>
         );
 
         return next().then(() => {


### PR DESCRIPTION
Legacy components expect a styletron engine to exist the `"styletron"` key of the legacy context API. This PR adds a legacy context provider to satisfy this requirement.

Legacy components can also use the modern engine because of the compat mixin this package uses.