### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "css-to-js-sourcemap-worker": "^2.0.1",
-    "prop-types": "^15.6.1",
     "styletron-engine-atomic": "^1.0.5"
   },
   "devDependencies": {
@@ -39,7 +38,6 @@
     "eslint-plugin-react": "7.10.0",
     "flow-bin": "0.72.0",
     "fusion-core": "^1.3.0",
-    "fusion-tokens": "^1.0.3",
     "nyc": "11.8.0",
     "prettier": "1.12.1",
     "react": "16.3.2",
@@ -50,7 +48,6 @@
   },
   "peerDependencies": {
     "fusion-core": "^1.3.0",
-    "fusion-tokens": "^1.0.3",
     "react": "14.x - 16.x",
     "styletron-react": "^4.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2724,10 +2724,6 @@ fusion-core@^1.3.0:
     ua-parser-js "^0.7.17"
     uuid "^3.2.1"
 
-fusion-tokens@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fusion-tokens/-/fusion-tokens-1.0.3.tgz#e247a076ef145337287e103ecbc42486594e96c5"
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -4470,7 +4466,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:


### PR DESCRIPTION
1) `prop-types` is never referenced anywhere
2) `fusion-tokens` is unused so there's no reason to specify it for dev and peer